### PR TITLE
Minor Fixes

### DIFF
--- a/Core.cpp
+++ b/Core.cpp
@@ -35,8 +35,8 @@
   boost::multiprecision::uint128_t Uint128;
 #endif
 
-#include <string.h>
-#include <time.h>
+#include <cstring>
+#include <ctime>
 #include <fcntl.h>
 #include <sys/time.h>
 #include <sys/stat.h>
@@ -7064,7 +7064,7 @@ Core<URV>::execFmadd_s(const DecodedInst* di)
   float f2 = fpRegs_.readSingle(di->op2());
   float f3 = fpRegs_.readSingle(di->op3());
   float res = std::fma(f1, f2, f3);
-  if (isnan(res))
+  if (std::isnan(res))
     res = std::numeric_limits<float>::quiet_NaN();
 
   fpRegs_.writeSingle(di->op0(), res);
@@ -7100,7 +7100,7 @@ Core<URV>::execFmsub_s(const DecodedInst* di)
   float f2 = fpRegs_.readSingle(di->op2());
   float f3 = fpRegs_.readSingle(di->op3());
   float res = std::fma(f1, f2, -f3);
-  if (isnan(res))
+  if (std::isnan(res))
     res = std::numeric_limits<float>::quiet_NaN();
 
   fpRegs_.writeSingle(di->op0(), res);
@@ -7136,7 +7136,7 @@ Core<URV>::execFnmsub_s(const DecodedInst* di)
   float f2 = fpRegs_.readSingle(di->op2());
   float f3 = fpRegs_.readSingle(di->op3());
   float res = std::fma(f1, f2, f3);
-  if (isnan(res))
+  if (std::isnan(res))
     res = std::numeric_limits<float>::quiet_NaN();
 
   fpRegs_.writeSingle(di->op0(), res);
@@ -7174,7 +7174,7 @@ Core<URV>::execFnmadd_s(const DecodedInst* di)
   float f2 = fpRegs_.readSingle(di->op2());
   float f3 = - fpRegs_.readSingle(di->op3());
   float res = std::fma(f1, f2, f3);
-  if (isnan(res))
+  if (std::isnan(res))
     res = std::numeric_limits<float>::quiet_NaN();
 
   fpRegs_.writeSingle(di->op0(), res);
@@ -7209,7 +7209,7 @@ Core<URV>::execFadd_s(const DecodedInst* di)
   float f1 = fpRegs_.readSingle(di->op1());
   float f2 = fpRegs_.readSingle(di->op2());
   float res = f1 + f2;
-  if (isnan(res))
+  if (std::isnan(res))
     res = std::numeric_limits<float>::quiet_NaN();
 
   fpRegs_.writeSingle(di->op0(), res);
@@ -7244,7 +7244,7 @@ Core<URV>::execFsub_s(const DecodedInst* di)
   float f1 = fpRegs_.readSingle(di->op1());
   float f2 = fpRegs_.readSingle(di->op2());
   float res = f1 - f2;
-  if (isnan(res))
+  if (std::isnan(res))
     res = std::numeric_limits<float>::quiet_NaN();
 
   fpRegs_.writeSingle(di->op0(), res);
@@ -7279,7 +7279,7 @@ Core<URV>::execFmul_s(const DecodedInst* di)
   float f1 = fpRegs_.readSingle(di->op1());
   float f2 = fpRegs_.readSingle(di->op2());
   float res = f1 * f2;
-  if (isnan(res))
+  if (std::isnan(res))
     res = std::numeric_limits<float>::quiet_NaN();
 
   fpRegs_.writeSingle(di->op0(), res);
@@ -7314,7 +7314,7 @@ Core<URV>::execFdiv_s(const DecodedInst* di)
   float f1 = fpRegs_.readSingle(di->op1());
   float f2 = fpRegs_.readSingle(di->op2());
   float res = f1 / f2;
-  if (isnan(res))
+  if (std::isnan(res))
     res = std::numeric_limits<float>::quiet_NaN();
 
   fpRegs_.writeSingle(di->op0(), res);
@@ -7348,7 +7348,7 @@ Core<URV>::execFsqrt_s(const DecodedInst* di)
 
   float f1 = fpRegs_.readSingle(di->op1());
   float res = std::sqrt(f1);
-  if (isnan(res))
+  if (std::isnan(res))
     res = std::numeric_limits<float>::quiet_NaN();
 
   fpRegs_.writeSingle(di->op0(), res);
@@ -7423,7 +7423,7 @@ static
 bool
 issnan(float f)
 {
-  if (isnan(f))
+  if (std::isnan(f))
     {
       Uint32FloatUnion ufu(f);
 
@@ -7439,7 +7439,7 @@ static
 bool
 issnan(double d)
 {
-  if (isnan(d))
+  if (std::isnan(d))
     {
       Uint64DoubleUnion udu(d);
 
@@ -7464,7 +7464,7 @@ Core<URV>::execFmin_s(const DecodedInst* di)
   float in2 = fpRegs_.readSingle(di->op2());
   float res = 0;
 
-  bool isNan1 = isnan(in1), isNan2 = isnan(in2);
+  bool isNan1 = std::isnan(in1), isNan2 = std::isnan(in2);
   if (isNan1 and isNan2)
     res = std::numeric_limits<float>::quiet_NaN();
   else if (isNan1)
@@ -7497,7 +7497,7 @@ Core<URV>::execFmax_s(const DecodedInst* di)
   float in2 = fpRegs_.readSingle(di->op2());
   float res = 0;
 
-  bool isNan1 = isnan(in1), isNan2 = isnan(in2);
+  bool isNan1 = std::isnan(in1), isNan2 = std::isnan(in2);
   if (isNan1 and isNan2)
     res = std::numeric_limits<float>::quiet_NaN();
   else if (isNan1)
@@ -7694,7 +7694,7 @@ Core<URV>::execFeq_s(const DecodedInst* di)
 
   URV res = 0;
 
-  if (isnan(f1) or isnan(f2))
+  if (std::isnan(f1) or std::isnan(f2))
     {
       if (issnan(f1) or issnan(f2))
 	setInvalidInFcsr();
@@ -7721,7 +7721,7 @@ Core<URV>::execFlt_s(const DecodedInst* di)
 
   URV res = 0;
 
-  if (isnan(f1) or isnan(f2))
+  if (std::isnan(f1) or std::isnan(f2))
     setInvalidInFcsr();
   else
     res = (f1 < f2)? 1 : 0;
@@ -7745,7 +7745,7 @@ Core<URV>::execFle_s(const DecodedInst* di)
 
   URV res = 0;
 
-  if (isnan(f1) or isnan(f2))
+  if (std::isnan(f1) or std::isnan(f2))
     setInvalidInFcsr();
   else
     res = (f1 <= f2)? 1 : 0;
@@ -8152,7 +8152,7 @@ Core<URV>::execFmadd_d(const DecodedInst* di)
   double f2 = fpRegs_.read(di->op2());
   double f3 = fpRegs_.read(di->op3());
   double res = std::fma(f1, f2, f3);
-  if (isnan(res))
+  if (std::isnan(res))
     res = std::numeric_limits<double>::quiet_NaN();
 
   fpRegs_.write(di->op0(), res);
@@ -8188,7 +8188,7 @@ Core<URV>::execFmsub_d(const DecodedInst* di)
   double f2 = fpRegs_.read(di->op2());
   double f3 = fpRegs_.read(di->op3());
   double res = std::fma(f1, f2, -f3);
-  if (isnan(res))
+  if (std::isnan(res))
     res = std::numeric_limits<double>::quiet_NaN();
 
   fpRegs_.write(di->op0(), res);
@@ -8224,7 +8224,7 @@ Core<URV>::execFnmsub_d(const DecodedInst* di)
   double f2 = fpRegs_.read(di->op2());
   double f3 = fpRegs_.read(di->op3());
   double res = std::fma(f1, f2, f3);
-  if (isnan(res))
+  if (std::isnan(res))
     res = std::numeric_limits<double>::quiet_NaN();
 
   fpRegs_.write(di->op0(), res);
@@ -8262,7 +8262,7 @@ Core<URV>::execFnmadd_d(const DecodedInst* di)
   double f2 = fpRegs_.read(di->op2());
   double f3 = - fpRegs_.read(di->op3());
   double res = std::fma(f1, f2, f3);
-  if (isnan(res))
+  if (std::isnan(res))
     res = std::numeric_limits<double>::quiet_NaN();
 
   fpRegs_.write(di->op0(), res);
@@ -8297,7 +8297,7 @@ Core<URV>::execFadd_d(const DecodedInst* di)
   double d1 = fpRegs_.read(di->op1());
   double d2 = fpRegs_.read(di->op2());
   double res = d1 + d2;
-  if (isnan(res))
+  if (std::isnan(res))
     res = std::numeric_limits<double>::quiet_NaN();
 
   fpRegs_.write(di->op0(), res);
@@ -8332,7 +8332,7 @@ Core<URV>::execFsub_d(const DecodedInst* di)
   double d1 = fpRegs_.read(di->op1());
   double d2 = fpRegs_.read(di->op2());
   double res = d1 - d2;
-  if (isnan(res))
+  if (std::isnan(res))
     res = std::numeric_limits<double>::quiet_NaN();
 
   fpRegs_.write(di->op0(), res);
@@ -8367,7 +8367,7 @@ Core<URV>::execFmul_d(const DecodedInst* di)
   double d1 = fpRegs_.read(di->op1());
   double d2 = fpRegs_.read(di->op2());
   double res = d1 * d2;
-  if (isnan(res))
+  if (std::isnan(res))
     res = std::numeric_limits<double>::quiet_NaN();
 
   fpRegs_.write(di->op0(), res);
@@ -8403,7 +8403,7 @@ Core<URV>::execFdiv_d(const DecodedInst* di)
   double d1 = fpRegs_.read(di->op1());
   double d2 = fpRegs_.read(di->op2());
   double res = d1 / d2;
-  if (isnan(res))
+  if (std::isnan(res))
     res = std::numeric_limits<double>::quiet_NaN();
 
   fpRegs_.write(di->op0(), res);
@@ -8488,7 +8488,7 @@ Core<URV>::execFmin_d(const DecodedInst* di)
   double in2 = fpRegs_.read(di->op2());
   double res = 0;
 
-  bool isNan1 = isnan(in1), isNan2 = isnan(in2);
+  bool isNan1 = std::isnan(in1), isNan2 = std::isnan(in2);
   if (isNan1 and isNan2)
     res = std::numeric_limits<double>::quiet_NaN();
   else if (isNan1)
@@ -8521,7 +8521,7 @@ Core<URV>::execFmax_d(const DecodedInst* di)
   double in2 = fpRegs_.read(di->op2());
   double res = 0;
 
-  bool isNan1 = isnan(in1), isNan2 = isnan(in2);
+  bool isNan1 = std::isnan(in1), isNan2 = std::isnan(in2);
   if (isNan1 and isNan2)
     res = std::numeric_limits<double>::quiet_NaN();
   else if (isNan1)
@@ -8562,7 +8562,7 @@ Core<URV>::execFcvt_d_s(const DecodedInst* di)
 
   float f1 = fpRegs_.readSingle(di->op1());
   double result = f1;
-  if (isnan(result))
+  if (std::isnan(result))
     result = std::numeric_limits<double>::quiet_NaN();
 
   fpRegs_.write(di->op0(), result);
@@ -8596,7 +8596,7 @@ Core<URV>::execFcvt_s_d(const DecodedInst* di)
 
   double d1 = fpRegs_.read(di->op1());
   float result = float(d1);
-  if (isnan(result))
+  if (std::isnan(result))
     result = std::numeric_limits<float>::quiet_NaN();
 
   fpRegs_.writeSingle(di->op0(), result);
@@ -8630,7 +8630,7 @@ Core<URV>::execFsqrt_d(const DecodedInst* di)
 
   double d1 = fpRegs_.read(di->op1());
   double res = std::sqrt(d1);
-  if (isnan(res))
+  if (std::isnan(res))
     res = std::numeric_limits<double>::quiet_NaN();
 
   fpRegs_.write(di->op0(), res);
@@ -8657,7 +8657,7 @@ Core<URV>::execFle_d(const DecodedInst* di)
 
   URV res = 0;
 
-  if (isnan(d1) or isnan(d2))
+  if (std::isnan(d1) or std::isnan(d2))
     setInvalidInFcsr();
   else
     res = (d1 <= d2)? 1 : 0;
@@ -8681,7 +8681,7 @@ Core<URV>::execFlt_d(const DecodedInst* di)
 
   URV res = 0;
 
-  if (isnan(d1) or isnan(d2))
+  if (std::isnan(d1) or std::isnan(d2))
     setInvalidInFcsr();
   else
     res = (d1 < d2)? 1 : 0;
@@ -8705,7 +8705,7 @@ Core<URV>::execFeq_d(const DecodedInst* di)
 
   URV res = 0;
 
-  if (isnan(d1) or isnan(d2))
+  if (std::isnan(d1) or std::isnan(d2))
     {
       if (issnan(d1) or issnan(d2))
 	setInvalidInFcsr();

--- a/CsRegs.cpp
+++ b/CsRegs.cpp
@@ -18,7 +18,7 @@
 
 #include <iostream>
 #include <algorithm>
-#include <assert.h>
+#include <cassert>
 #include "CsRegs.hpp"
 
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -29,8 +29,7 @@ BOOST_INC := $(wildcard $(BOOST_DIR) $(BOOST_DIR)/include)
 BOOST_LIB_DIR := $(wildcard $(BOOST_DIR)/stage/lib $(BOOST_DIR)/lib)
 
 # Specify only the basename of the Boost libraries
-BOOST_LIBS := boost_program_options \
-              boost_system
+BOOST_LIBS := boost_program_options
 
 # Add extra dependency libraries here
 EXTRA_LIBS := -lpthread
@@ -91,7 +90,7 @@ RVCORE_SRCS := IntRegs.cpp CsRegs.cpp FpRegs.cpp instforms.cpp \
 SRCS_CXX += $(RVCORE_SRCS) whisper.cpp
 
 # List of All C Sources for the project
-SRCS_C := linenoise.c
+SRCS_C :=
 
 # List of all object files for the project
 OBJS_GEN := $(SRCS_CXX:%=$(BUILD_DIR)/%.o) $(SRCS_C:%=$(BUILD_DIR)/%.o)

--- a/InstEntry.cpp
+++ b/InstEntry.cpp
@@ -16,7 +16,7 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-#include <assert.h>
+#include <cassert>
 #include "InstEntry.hpp"
 
 using namespace WdRiscv;

--- a/Memory.cpp
+++ b/Memory.cpp
@@ -20,8 +20,8 @@
 #include <fstream>
 #include <sstream>
 #include <string>
-#include <math.h>
-#include <stdlib.h>
+#include <cmath>
+#include <cstdlib>
 #ifndef __MINGW64__
 #include <sys/mman.h>
 #endif

--- a/Server.cpp
+++ b/Server.cpp
@@ -21,7 +21,7 @@
 #include <map>
 #include <algorithm>
 #include <boost/format.hpp>
-#include <string.h>
+#include <cstring>
 #ifdef __MINGW64__
 #include <winsock2.h>
 #else
@@ -30,7 +30,7 @@
 #endif
 
 #define __STDC_FORMAT_MACROS
-#include <inttypes.h>
+#include <cinttypes>
 
 #include "WhisperMessage.h"
 #include "Server.hpp"

--- a/emulateSyscall.cpp
+++ b/emulateSyscall.cpp
@@ -19,8 +19,8 @@
 #include <iomanip>
 #include <iostream>
 
-#include <string.h>
-#include <time.h>
+#include <cstring>
+#include <ctime>
 #include <sys/times.h>
 #include <fcntl.h>
 #include <sys/time.h>

--- a/gdb.cpp
+++ b/gdb.cpp
@@ -16,8 +16,8 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-#include <stdio.h>
-#include <signal.h>
+#include <cstdio>
+#include <csignal>
 #include <iostream>
 #include <sstream>
 #include <boost/format.hpp>

--- a/instforms.cpp
+++ b/instforms.cpp
@@ -16,7 +16,7 @@
 // this program. If not, see <https://www.gnu.org/licenses/>.
 //
 
-#include <assert.h>
+#include <cassert>
 #include "instforms.hpp"
 
 using namespace WdRiscv;

--- a/linenoise.hpp
+++ b/linenoise.hpp
@@ -143,11 +143,11 @@
 #define write win32_write
 #define read _read
 #endif
-#include <stdlib.h>
-#include <stdio.h>
-#include <errno.h>
-#include <string.h>
-#include <ctype.h>
+#include <cstdlib>
+#include <cstdio>
+#include <cerrno>
+#include <cstring>
+#include <cctype>
 #include <sys/types.h>
 #include <string>
 #include <fstream>


### PR DESCRIPTION
* Fix `#include` statments to include C++ Standard library headers
  instead of `C` style headers.
* Fix `isnan` function is available only in `std` namespace, this fixes the
  compilation on multuple platforms.
* Fix `GNUmakefile` remove unused `boost_system` library dependency and cleanup
  `SRCS_C` variable for removed source file.