### PR TITLE
Fix HartConfig class template methods linker errors

### DIFF
--- a/HartConfig.cpp
+++ b/HartConfig.cpp
@@ -1021,30 +1021,11 @@ HartConfig::finalizeCsrConfig(std::vector<Hart<URV>*>& harts) const
   return true;
 }
 
+/// Instantiate template member functions
+template bool HartConfig::applyConfig<uint32_t>(Hart<uint32_t> &, bool) const;
+template bool HartConfig::applyConfig<uint64_t>(Hart<uint64_t> &, bool) const;
+template bool HartConfig::applyMemoryConfig<uint32_t>(Hart<uint32_t> &, bool) const;
+template bool HartConfig::applyMemoryConfig<uint64_t>(Hart<uint64_t> &, bool) const;
+template bool HartConfig::finalizeCsrConfig<uint32_t>(std::vector<Hart<uint32_t>* > &) const;
+template bool HartConfig::finalizeCsrConfig<uint64_t>(std::vector<Hart<uint64_t>* > &) const;
 
-/// This is never called. It is here to force instantiation of templated
-/// methods.
-bool
-HartConfig::apply(HartConfig& conf, Hart<uint32_t>& hart, bool verbose)
-{
-  conf.applyMemoryConfig(hart, verbose);
-
-  std::vector<Hart<uint32_t>*> vec;
-  conf.finalizeCsrConfig(vec);
-
-  return conf.applyConfig(hart, verbose);
-}
-
-
-/// This is never called. It is here to force instantiation of templated
-/// methods.
-bool
-HartConfig::apply(HartConfig& conf, Hart<uint64_t>& hart, bool verbose)
-{
-  conf.applyMemoryConfig(hart, verbose);
-
-  std::vector<Hart<uint64_t>*> vec;
-  conf.finalizeCsrConfig(vec);
-
-  return conf.applyConfig(hart, verbose);
-}

--- a/HartConfig.hpp
+++ b/HartConfig.hpp
@@ -82,12 +82,6 @@ namespace WdRiscv
 
   private:
 
-    /// Force instantiation of applyConfig(Hart<uint32_t>, bool).
-    static bool apply(HartConfig&, Hart<uint32_t>&, bool);
-
-    /// Force instantiation of applyConfig(Hart<uint64_t>, bool).
-    static bool apply(HartConfig&, Hart<uint64_t>&, bool);
-
     HartConfig(const HartConfig&) = delete;
     void operator= (const HartConfig&) = delete;
 


### PR DESCRIPTION
* Remove HartConfig::apply static method since it does not serve any purpose.
* Explicitly instantiate HartConfig class following API's in .cpp:
  * HartConfig::applyConfig
  * HartConfig::applyMemoryConfig
  * HartConfig::finalizeCsrConfig